### PR TITLE
Add pull_request_target option for github actions

### DIFF
--- a/.github/workflows/check_on_push_pr.yml
+++ b/.github/workflows/check_on_push_pr.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
       branches:
       - master
+  pull_request_target:
+      types: [labeled]
 
 jobs:
   lint:


### PR DESCRIPTION
외부 fork에서 PR을 보낼 시, secret 접근 권한이 없어서 테스트 오류가 나는 문제 해결