### PR TITLE
SRT 중복 예약 기능 수정

### DIFF
--- a/SRT/srt.py
+++ b/SRT/srt.py
@@ -325,11 +325,8 @@ class SRT:
         r = self._session.post(url=url, data=data)
         parser = SRTResponseData(r.text)
 
-        dup_msg = "요청하신 승차권과 동일한 시간대에 예약 또는 발권하신 승차권이 존재합니다."
         if not parser.success():
             raise SRTResponseError(parser.message())
-        elif dup_msg in parser.message():
-            raise SRTDuplicateError(parser.message())
 
         self._log(parser.message())
         reservation_result = parser.get_all()["reservListMap"][0]


### PR DESCRIPTION
안녕하세요. SRT 서버 로직에서 기존에 예약된 표 혹은 예매한 표가 있을 때도 동일한 티켓 예약이 가능합니다. 그래서 중복으로 예약/예매가 가능한데요. SRT 라이브러리에서는 오류 반환을 하여 동일한 티켓이 예약/예매가 안되는 것처럼 인지될 수 있다고 생각합니다. 그래서 `SRTDuplicateError` 오류 반환하는 로직을 제거하고 `self._log(parser.message())` 로그로 사용자에게 알리는 게 좋다고 생각합니다.