### PR TITLE
SRT 중복 예약 오류 반환 로직 제거

### DIFF
--- a/SRT/srt.py
+++ b/SRT/srt.py
@@ -5,7 +5,6 @@ import requests  # type: ignore
 
 from .constants import STATION_CODE
 from .errors import (
-    SRTDuplicateError,
     SRTError,
     SRTLoginError,
     SRTNotLoggedInError,
@@ -325,11 +324,8 @@ class SRT:
         r = self._session.post(url=url, data=data)
         parser = SRTResponseData(r.text)
 
-        dup_msg = "요청하신 승차권과 동일한 시간대에 예약 또는 발권하신 승차권이 존재합니다."
         if not parser.success():
             raise SRTResponseError(parser.message())
-        elif dup_msg in parser.message():
-            raise SRTDuplicateError(parser.message())
 
         self._log(parser.message())
         reservation_result = parser.get_all()["reservListMap"][0]

--- a/SRT/srt.py
+++ b/SRT/srt.py
@@ -4,12 +4,7 @@ from datetime import datetime, timedelta
 import requests  # type: ignore
 
 from .constants import STATION_CODE
-from .errors import (
-    SRTError,
-    SRTLoginError,
-    SRTNotLoggedInError,
-    SRTResponseError,
-)
+from .errors import SRTError, SRTLoginError, SRTNotLoggedInError, SRTResponseError
 from .passenger import Adult, Passenger
 from .reservation import SRTReservation, SRTTicket
 from .response_data import SRTResponseData


### PR DESCRIPTION
안녕하세요. SRT 서버 로직에서 기존에 예약된 표 혹은 예매한 표가 있을 때도 동일한 티켓 예약이 가능합니다. 수정 전의 버전을 보면, SRT/srt.py의 325 line에서 SRT 서버에 예약 요청하여 중복 예약이 가능합니다. 한편, 이후 로직(328~342line)에서 중복예약인 경우 `SRTDuplicateError` 오류 반환을 하기 때문에 라이브러리 사용자가 동일한 티켓이 예약/예매가 안되는 것으로 인지할 수 있다고 생각합니다. 그래서 `SRTDuplicateError` 오류 반환하는 로직을 제거하고 `self._log(parser.message())` 등의 로그로 사용자에게 알리는 게 좋다고 생각합니다.