### PR TITLE
CI Don't run test on pull request by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,6 @@ on:
   push:
       branches:
       - master
-  pull_request:
-      branches:
-      - master
   pull_request_target:
       types: [labeled]
 
@@ -45,7 +42,7 @@ jobs:
           SRT_USERNAME: ${{ secrets.SRT_USERNAME }}
         run: |
           pip install pytest
-          pytest SRT -x
+          pytest SRT -x -v
   docs:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
GHA secret 권한 문제로 메인테이너가 label을 붙였을 때만 CI가 실행되도록 변경