### PR TITLE
Remove lint actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,6 @@ on:
       types: [labeled]
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - uses: pre-commit/action@v3.0.0
   check:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
pre-commit/action is deprecated, we have pre-commit.ci so we don't need this