### PR TITLE
feat: 결제 완료된 티켓 리스트를 가져오는 메소드 추가

### DIFF
--- a/SRT/reservation.py
+++ b/SRT/reservation.py
@@ -12,7 +12,7 @@ class SRTTicket:
         "5": "어린이",
     }
 
-    def __init__(self, reservation_number, data):
+    def __init__(self, data):
         self.car = data["scarNo"]
         self.seat = data["seatNo"]
         self.seat_type_code = data["psrmClCd"]
@@ -23,8 +23,6 @@ class SRTTicket:
         self.price = int(data["rcvdAmt"])
         self.original_price = int(data["stdrPrc"])
         self.discount = int(data["dcntPrc"])
-
-        self.reservation_number = reservation_number
 
     def __str__(self):
         return self.dump()
@@ -67,6 +65,7 @@ class SRTReservation:
         self.payment_date = pay["iseLmtDt"]
         self.payment_time = pay["iseLmtTm"]
 
+        self.paid = (pay["stlFlg"] == "Y")  # 결제 여부
         self._tickets = tickets
 
     def __str__(self):
@@ -81,8 +80,7 @@ class SRTReservation:
             "{month}월 {day}일, "
             "{dep}~{arr}"
             "({dep_hour}:{dep_min}~{arr_hour}:{arr_min}) "
-            "{cost}원({seats}석), "
-            "구입기한 {pay_month}월 {pay_day}일 {pay_hour}:{pay_min}"
+            "{cost}원({seats}석)"
         ).format(
             name=self.train_name,
             month=self.dep_date[4:6],
@@ -95,12 +93,16 @@ class SRTReservation:
             arr_min=self.arr_time[2:4],
             cost=self.total_cost,
             seats=self.seat_count,
-            pay_month=self.payment_date[4:6],
-            pay_day=self.payment_date[6:8],
-            pay_hour=self.payment_time[0:2],
-            pay_min=self.payment_time[2:4],
         )
-
+        if not self.paid:
+            d += (
+                ", 구입기한 {pay_month}월 {pay_day}일 {pay_hour}:{pay_min}"
+            ).format(
+                pay_month=self.payment_date[4:6],
+                pay_day=self.payment_date[6:8],
+                pay_hour=self.payment_time[0:2],
+                pay_min=self.payment_time[2:4],
+            )
         return d
 
     @property

--- a/SRT/reservation.py
+++ b/SRT/reservation.py
@@ -12,7 +12,7 @@ class SRTTicket:
         "5": "어린이",
     }
 
-    def __init__(self, data):
+    def __init__(self, reservation_number, data):
         self.car = data["scarNo"]
         self.seat = data["seatNo"]
         self.seat_type_code = data["psrmClCd"]
@@ -23,6 +23,8 @@ class SRTTicket:
         self.price = int(data["rcvdAmt"])
         self.original_price = int(data["stdrPrc"])
         self.discount = int(data["dcntPrc"])
+
+        self.reservation_number = reservation_number
 
     def __str__(self):
         return self.dump()

--- a/SRT/srt.py
+++ b/SRT/srt.py
@@ -382,8 +382,8 @@ class SRT:
         pay_data = parser.get_all()["payListMap"]
         reservations = []
         for train, pay in zip(train_data, pay_data):
-            if pay['stlFlg'] == 'Y':  # 결제완료된 예약 내역은 넘어가기
-               continue
+            if pay["stlFlg"] == "Y":  # 결제완료된 예약 내역은 넘어가기
+                continue
             ticket = self.ticket_info(train["pnrNo"])
             reservation = SRTReservation(train, pay, ticket)
             reservations.append(reservation)
@@ -450,7 +450,10 @@ class SRT:
         if not parser.success():
             raise SRTResponseError(parser.message())
 
-        tickets = [SRTTicket(reservation, ticket) for ticket in parser.get_all()["trainListMap"]]
+        tickets = [
+            SRTTicket(reservation, ticket)
+            for ticket in parser.get_all()["trainListMap"]
+        ]
 
         return tickets
 

--- a/SRT/srt.py
+++ b/SRT/srt.py
@@ -410,11 +410,12 @@ class SRT:
 
         self._log(parser.message())
 
-        rs_data = parser.get_all()["rsListMap"]
         tickets = []
-        for data in rs_data:
-            ticket = self.ticket_info(data["pnrNo"])[0]
-            tickets.append(ticket)
+        rs_data = parser.get_all()["rsListMap"]
+        if rs_data is not None:
+            for data in rs_data:
+                ticket = self.ticket_info(data["pnrNo"])[0]
+                tickets.append(ticket)
 
         return tickets
 

--- a/SRT/tests/test_srt.py
+++ b/SRT/tests/test_srt.py
@@ -44,10 +44,6 @@ def test_get_reservations(srt):
     srt.get_reservations()
 
 
-def test_get_tickets(srt):
-    srt.get_tickets()
-
-
 def test_reserve_and_cancel(srt, pytestconfig):
     pytestconfig.getoption("--full", skip=True)
     dep = "수서"

--- a/SRT/tests/test_srt.py
+++ b/SRT/tests/test_srt.py
@@ -44,6 +44,10 @@ def test_get_reservations(srt):
     srt.get_reservations()
 
 
+def test_get_tickets(srt):
+    srt.get_tickets()
+
+
 def test_reserve_and_cancel(srt, pytestconfig):
     pytestconfig.getoption("--full", skip=True)
     dep = "수서"

--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -18,6 +18,7 @@ export SRT_PASSWORD=<YOUR_SRT_PASSWORD>
 # set SRT_PASSWORD=<YOUR_SRT_PASSWORD>
 
 pip install -r requirements/test.txt
+pip install -r requirements.txt
 
 black SRT
 pytest SRT -v -x


### PR DESCRIPTION
# Summary
  - 결제 완료된 티켓 리스트를 가져오는 메소드 추가

# What's Changed
- 기존 `get_reservations` 메소드는 결제 미완료/완료를 포함하여 모든 예약내역 리스트를 가져왔습니다. 하지만, 결제 완료된 티켓 정보와 미완료된 티켓 정보를 분리해서 보고 싶은 경우가 있습니다. 따라서 다음과 같이 변경했습니다.
  - `SRTTicket` 타입의 원소 리스트를 반환하는 `get_tickets` 메소드 추가
  - 어떤 예약내역을 결제하였는지 정보를 포함하기 위해 `SRTTicket`에 `reservation_number` 속성 추가
  - `get_reservations` 메소드에서 결제 완료된 예약 내역은 제외 (`stlFlg` 값 이용)
- 새로운 메소드에 대한 테스트 코드 추가
- `contribution.md` 수정

# How to Test
- `pytest SRT -v -x`
- 시나리오 테스트
```python
from SRT import SRT, SeatType
session = SRT('your-id', 'your-password')
trains = session.search_train('수서', '동탄', '20230425', '000000')
session.reserve(trains[0], special_seat=SeatType.GENERAL_FIRST)
reservations = session.get_reservations()
# ---> 해당 예약 내역 결제 진행--->
tickets= session.get_tickets()
```