### PR TITLE
Remove the login status check statement from the search_train function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- `search_train()` 메소드가 더이상 사용자의 로그인 여부를 확인하지 않음.
+  ([#238](https://github.com/ryanking13/SRT/pull/238))
+
 - Public API에 대한 static typing 추가
   ([#234](https://github.com/ryanking13/SRT/pull/234))
 

--- a/SRT/srt.py
+++ b/SRT/srt.py
@@ -178,9 +178,6 @@ class SRT:
             list[:class:`SRTTrain`]: 열차 리스트
         """
 
-        if not self.is_login:
-            raise SRTNotLoggedInError()
-
         if dep not in STATION_CODE:
             raise ValueError(f'Station "{dep}" not exists')
         if arr not in STATION_CODE:


### PR DESCRIPTION
https://github.com/ryanking13/SRT/issues/237#issue-1828383145

위 이슈에서 언급한 것처럼, 기존 `srt.py` 스크립트의 `search_train` 함수에서 불필요하게 사용자의 로그인 여부를 확인하던 부분을 제거했습니다.