### PR TITLE
add ITX-maeum train to TRAIN_NAME in constants.py

### DIFF
--- a/SRT/constants.py
+++ b/SRT/constants.py
@@ -46,6 +46,7 @@ TRAIN_NAME = {
     "09": "ITX-청춘",
     "10": "KTX-산천",
     "17": "SRT",
+    "18": "ITX-마음",
 }
 
 WINDOW_SEAT = {None: "000", True: "012", False: "013"}


### PR DESCRIPTION
2023년 9월부터 ITX-마음 기차가 신규 개통됨에 따라, 특정 구간 기차 검색시 해당 train_code 인 18을 찾지 못해 KeyError 발생합니다.
따라서 기차 목록에 `train_code`가  `18`인 'ITX-마음' 추가가 필요합니다.

**오류메시지**
<img width="566" alt="스크린샷 2024-01-10 오후 11 40 17" src="https://github.com/ryanking13/SRT/assets/38124811/9b9c00cc-46d0-4936-9b24-d317f4328074">
  

**문제의 기차 : 오전 10시 42분 부산 -> 동대구**  
<img width="711" alt="스크린샷 2024-01-10 오후 11 41 40" src="https://github.com/ryanking13/SRT/assets/38124811/378f9119-1fb1-444b-8edd-359c898c80d2">
